### PR TITLE
Add wall model slip -- round 2

### DIFF
--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -753,31 +753,22 @@ def get_interface_boundaries(
             * (0*fluid_state.temperature+1))
 
         if interface_noslip:
-            fluid_interface_boundaries = {
-                kappa_tpair.dd.domain_tag: InterfaceFluidBoundary(
-                    kappa_tpair.ext,
-                    temperature_tpair.ext,
-                    grad_temperature_tpair.ext,
-                    wall_penalty_amount,
-                    lengthscales=op.project(dcoll,
-                        fluid_dd, temperature_tpair.dd, fluid_lengthscales))
-                for kappa_tpair, temperature_tpair, grad_temperature_tpair in zip(
-                    kappa_inter_vol_tpairs[wall_dd, fluid_dd],
-                    temperature_inter_vol_tpairs[wall_dd, fluid_dd],
-                    grad_temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
+            fluid_bc_class = InterfaceFluidBoundary
         else:
-            fluid_interface_boundaries = {
-                kappa_tpair.dd.domain_tag: InterfaceFluidSlipBoundary(
-                    kappa_tpair.ext,
-                    temperature_tpair.ext,
-                    grad_temperature_tpair.ext,
-                    wall_penalty_amount,
-                    lengthscales=op.project(dcoll,
-                        fluid_dd, temperature_tpair.dd, fluid_lengthscales))
-                for kappa_tpair, temperature_tpair, grad_temperature_tpair in zip(
-                    kappa_inter_vol_tpairs[wall_dd, fluid_dd],
-                    temperature_inter_vol_tpairs[wall_dd, fluid_dd],
-                    grad_temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
+            fluid_bc_class = InterfaceFluidSlipBoundary
+
+        fluid_interface_boundaries = {
+            kappa_tpair.dd.domain_tag: fluid_bc_class(
+                kappa_tpair.ext,
+                temperature_tpair.ext,
+                grad_temperature_tpair.ext,
+                wall_penalty_amount,
+                lengthscales=op.project(dcoll,
+                    fluid_dd, temperature_tpair.dd, fluid_lengthscales))
+            for kappa_tpair, temperature_tpair, grad_temperature_tpair in zip(
+                kappa_inter_vol_tpairs[wall_dd, fluid_dd],
+                temperature_inter_vol_tpairs[wall_dd, fluid_dd],
+                grad_temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
 
         wall_interface_boundaries = {
             kappa_tpair.dd.domain_tag: InterfaceWallBoundary(

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -711,6 +711,11 @@ def get_interface_boundaries(
         _grad_temperature_inter_vol_tpairs=None):
     # FIXME: Incomplete docs
     """Get the fluid-wall interface boundaries."""
+    if interface_noslip:
+        fluid_bc_class = InterfaceFluidBoundary
+    else:
+        fluid_bc_class = InterfaceFluidSlipBoundary
+
     include_gradient = (
         fluid_grad_temperature is not None and wall_grad_temperature is not None)
 
@@ -752,11 +757,6 @@ def get_interface_boundaries(
                 fluid_state.array_context, dcoll, fluid_dd)
             * (0*fluid_state.temperature+1))
 
-        if interface_noslip:
-            fluid_bc_class = InterfaceFluidBoundary
-        else:
-            fluid_bc_class = InterfaceFluidSlipBoundary
-
         fluid_interface_boundaries = {
             kappa_tpair.dd.domain_tag: fluid_bc_class(
                 kappa_tpair.ext,
@@ -780,22 +780,13 @@ def get_interface_boundaries(
                 temperature_inter_vol_tpairs[fluid_dd, wall_dd],
                 grad_temperature_inter_vol_tpairs[fluid_dd, wall_dd])}
     else:
-        if interface_noslip:
-            fluid_interface_boundaries = {
-                kappa_tpair.dd.domain_tag: InterfaceFluidBoundary(
-                    kappa_tpair.ext,
-                    temperature_tpair.ext)
-                for kappa_tpair, temperature_tpair in zip(
-                    kappa_inter_vol_tpairs[wall_dd, fluid_dd],
-                    temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
-        else:
-            fluid_interface_boundaries = {
-                kappa_tpair.dd.domain_tag: InterfaceFluidSlipBoundary(
-                    kappa_tpair.ext,
-                    temperature_tpair.ext)
-                for kappa_tpair, temperature_tpair in zip(
-                    kappa_inter_vol_tpairs[wall_dd, fluid_dd],
-                    temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
+        fluid_interface_boundaries = {
+            kappa_tpair.dd.domain_tag: fluid_bc_class(
+                kappa_tpair.ext,
+                temperature_tpair.ext)
+            for kappa_tpair, temperature_tpair in zip(
+                kappa_inter_vol_tpairs[wall_dd, fluid_dd],
+                temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
 
         wall_interface_boundaries = {
             kappa_tpair.dd.domain_tag: InterfaceWallBoundary(

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -54,7 +54,6 @@ from mirgecom.boundary import PrescribedFluidBoundary
 from mirgecom.fluid import make_conserved
 from mirgecom.flux import num_flux_central
 from mirgecom.inviscid import inviscid_facial_flux_rusanov
-from mirgecom.viscous import viscous_facial_flux_central
 from mirgecom.viscous import viscous_facial_flux_harmonic
 from mirgecom.gas_model import (
     make_fluid_state,

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -54,6 +54,7 @@ from mirgecom.boundary import PrescribedFluidBoundary
 from mirgecom.fluid import make_conserved
 from mirgecom.flux import num_flux_central
 from mirgecom.inviscid import inviscid_facial_flux_rusanov
+from mirgecom.viscous import viscous_facial_flux_central
 from mirgecom.viscous import viscous_facial_flux_harmonic
 from mirgecom.gas_model import (
     make_fluid_state,
@@ -102,6 +103,263 @@ class _WallGradTag:
 class _WallOperatorTag:
     pass
 
+
+class InterfaceFluidSlipBoundary(PrescribedFluidBoundary):
+    """Interface boundary condition for the fluid side."""
+
+    # FIXME: Incomplete docs
+    def __init__(
+            self, ext_kappa, ext_t, ext_grad_t=None, heat_flux_penalty_amount=None,
+            lengthscales=None):
+        """Initialize InterfaceFluidBoundary."""
+        PrescribedFluidBoundary.__init__(
+            self,
+            boundary_state_func=self.get_external_state,
+            boundary_grad_av_func=self.get_external_grad_av,
+            boundary_temperature_func=self.get_external_t,
+            boundary_gradient_temperature_func=self.get_external_grad_t,
+            inviscid_flux_func=self.inviscid_wall_flux,
+            viscous_flux_func=self.viscous_wall_flux,
+            boundary_gradient_cv_func=self.get_external_grad_cv
+        )
+        self.ext_kappa = ext_kappa
+        self.ext_t = ext_t
+        self.ext_grad_t = ext_grad_t
+        self.heat_flux_penalty_amount = heat_flux_penalty_amount
+        self.lengthscales = lengthscales
+
+    # NOTE: The BC for species mass is y_+ = y_-, I think that is OK here
+    #       The BC for species mass fraction gradient is set down inside the
+    #       `viscous_flux` method.
+    def get_external_state(self, dcoll, dd_bdry, gas_model, state_minus, **kwargs):
+        """Get the exterior solution on the boundary."""
+        if dd_bdry.discretization_tag is not DISCR_TAG_BASE:
+            dd_bdry_base = dd_bdry.with_discr_tag(DISCR_TAG_BASE)
+            ext_kappa = op.project(dcoll, dd_bdry_base, dd_bdry, self.ext_kappa)
+            ext_t = op.project(dcoll, dd_bdry_base, dd_bdry, self.ext_t)
+        else:
+            ext_kappa = self.ext_kappa
+            ext_t = self.ext_t
+
+        cv_minus = state_minus.cv
+
+        # Cancel out the momentum in the normal direction
+        actx = state_minus.array_context
+        nhat = actx.thaw(dcoll.normal(dd_bdry))
+        ext_mom = cv_minus.momentum - np.dot(cv_minus.momentum, nhat)*nhat
+
+        # Compute the energy
+        ext_internal_energy = (
+            cv_minus.mass
+            * gas_model.eos.get_internal_energy(
+                temperature=ext_t,
+                species_mass_fractions=cv_minus.species_mass_fractions))
+        #ext_kinetic_energy = gas_model.eos.kinetic_energy(cv_minus)
+        ext_kinetic_energy = 0.5*np.dot(ext_mom, ext_mom)/cv_minus.mass
+        ext_energy = ext_internal_energy + ext_kinetic_energy
+
+        # Form the external boundary solution with the new momentum and energy.
+        ext_cv = make_conserved(
+            dim=state_minus.dim, mass=cv_minus.mass, energy=ext_energy,
+            momentum=ext_mom, species_mass=cv_minus.species_mass)
+
+        def replace_thermal_conductivity(state, kappa):
+            new_tv = replace(state.tv, thermal_conductivity=kappa)
+            return replace(state, tv=new_tv)
+
+        return replace_thermal_conductivity(
+            make_fluid_state(
+                cv=ext_cv, gas_model=gas_model,
+                temperature_seed=state_minus.temperature),
+            ext_kappa)
+
+    def inviscid_wall_flux(self, dcoll, dd_bdry, gas_model, state_minus,
+            numerical_flux_func=inviscid_facial_flux_rusanov, **kwargs):
+        """Return Riemann flux using state with mom opposite of interior state."""
+        dd_bdry = as_dofdesc(dd_bdry)
+        normal = state_minus.array_context.thaw(dcoll.normal(dd_bdry))
+        ext_mom = (state_minus.momentum_density
+                   - 2.0*np.dot(state_minus.momentum_density, normal)*normal)
+        # NOTE: For the inviscid/advection part we set mom_+ = -mom_-, and
+        #       use energy_+ = energy_-, per [Mengaldo_2014]_.
+        wall_cv = make_conserved(dim=state_minus.dim,
+                                 mass=state_minus.mass_density,
+                                 momentum=ext_mom,
+                                 energy=state_minus.energy_density,
+                                 species_mass=state_minus.species_mass_density)
+        wall_state = make_fluid_state(cv=wall_cv, gas_model=gas_model,
+                                      temperature_seed=state_minus.temperature)
+        state_pair = TracePair(dd_bdry, interior=state_minus, exterior=wall_state)
+
+        return numerical_flux_func(state_pair, gas_model, normal)
+
+    def get_external_grad_av(self, dcoll, dd_bdry, grad_av_minus, **kwargs):
+        """Get the exterior grad(Q) on the boundary."""
+        # Grab some boundary-relevant data
+        actx = grad_av_minus.array_context
+
+        # Grab a unit normal to the boundary
+        nhat = actx.thaw(dcoll.normal(dd_bdry))
+
+        # Apply a Neumann condition on the energy gradient
+        # Should probably compute external energy gradient using external temperature
+        # gradient, but that is a can of worms
+        ext_grad_energy = \
+            grad_av_minus.energy - 2 * np.dot(grad_av_minus.energy, nhat) * nhat
+
+        # uh oh - we don't have the necessary data to compute grad_y from grad_av
+        # from mirgecom.fluid import species_mass_fraction_gradient
+        # grad_y_minus = species_mass_fraction_gradient(state_minus.cv,
+        #                                               grad_cv_minus)
+        # grad_y_plus = grad_y_minus - np.outer(grad_y_minus@normal, normal)
+        # grad_species_mass_plus = 0.*grad_y_plus
+        # This re-stuffs grad_y+ back into grad_cv+, skipit; we did not split AVs
+        # for i in range(state_minus.nspecies):
+        #    grad_species_mass_plus[i] = (state_minus.mass_density*grad_y_plus[i]
+        #        + state_minus.species_mass_fractions[i]*grad_cv_minus.mass)
+        ext_grad_species_mass = (
+            grad_av_minus.species_mass
+            - np.outer(grad_av_minus.species_mass @ nhat, nhat))
+
+        return make_conserved(
+            grad_av_minus.dim, mass=grad_av_minus.mass, energy=ext_grad_energy,
+            momentum=grad_av_minus.momentum, species_mass=ext_grad_species_mass)
+
+    def get_external_grad_cv(self, state_minus, state_plus, grad_cv_minus, normal, **kwargs):
+        """
+        Return external grad(CV) used in the boundary calculation of viscous flux.
+
+        Specify the velocity gradients on the external state to ensure zero
+        energy and momentum flux due to shear stresses.
+
+        Gradients of species mass fractions are set to zero in the normal direction
+        to ensure zero flux of species across the boundary.
+        """
+        grad_species_mass_plus = 1.*grad_cv_minus.species_mass
+        if state_minus.nspecies > 0:
+            from mirgecom.fluid import species_mass_fraction_gradient
+            grad_y_minus = species_mass_fraction_gradient(state_minus.cv,
+                                                          grad_cv_minus)
+            grad_y_plus = grad_y_minus - np.outer(grad_y_minus@normal, normal)
+            grad_species_mass_plus = 0.*grad_y_plus
+
+            for i in range(state_minus.nspecies):
+                grad_species_mass_plus[i] = \
+                    (state_minus.mass_density*grad_y_plus[i]
+                     + state_minus.species_mass_fractions[i]*grad_cv_minus.mass)
+
+        # normal velocity on the surface is zero,
+        vel_plus = state_plus.velocity
+
+        from mirgecom.fluid import velocity_gradient
+        grad_v_minus = velocity_gradient(state_minus.cv, grad_cv_minus)
+
+        # rotate the velocity gradient tensor into the normal direction
+        from mirgecom.boundary import _get_rotation_matrix
+        rotation_matrix = _get_rotation_matrix(normal)
+        grad_v_normal = rotation_matrix@grad_v_minus@rotation_matrix.T
+
+        # set the normal component of the tangential velocity to 0
+        for i in range(state_minus.dim-1):
+            grad_v_normal[i+1][0] = 0.*grad_v_normal[i+1][0]
+
+        # get the gradient on the plus side in the global coordiate space
+        grad_v_plus = rotation_matrix.T@grad_v_normal@rotation_matrix
+
+        # construct grad(mom)
+        grad_mom_plus = (state_minus.mass_density*grad_v_plus
+                         + np.outer(vel_plus, grad_cv_minus.mass))
+
+        return make_conserved(grad_cv_minus.dim,
+                              mass=grad_cv_minus.mass,
+                              energy=grad_cv_minus.energy,
+                              momentum=grad_mom_plus,
+                              species_mass=grad_species_mass_plus)
+
+    def viscous_wall_flux(
+            self, dcoll, dd_bdry, gas_model, state_minus, grad_cv_minus,
+            grad_t_minus, numerical_flux_func=viscous_facial_flux_harmonic,
+            **kwargs):
+        """Return the boundary flux for the divergence of the viscous flux."""
+        if self.heat_flux_penalty_amount is None:
+            raise ValueError("Boundary does not have heat flux penalty amount.")
+        if self.lengthscales is None:
+            raise ValueError("Boundary does not have length scales data.")
+
+        dd_bdry = as_dofdesc(dd_bdry)
+        dd_bdry_base = dd_bdry.with_discr_tag(DISCR_TAG_BASE)
+        from mirgecom.viscous import viscous_flux
+        actx = state_minus.array_context
+        normal = actx.thaw(dcoll.normal(dd_bdry))
+
+        state_plus = self.get_external_state(
+            dcoll=dcoll, dd_bdry=dd_bdry, gas_model=gas_model,
+            state_minus=state_minus, **kwargs)
+        grad_cv_bc = self.get_external_grad_cv(
+            state_minus=state_minus, state_plus=state_plus,
+            grad_cv_minus=grad_cv_minus, normal=normal,
+            **kwargs)
+
+        grad_t_plus = self.get_external_grad_t(
+            dcoll=dcoll, dd_bdry=dd_bdry, gas_model=gas_model,
+            state_minus=state_minus, grad_cv_minus=grad_cv_minus,
+            grad_t_minus=grad_t_minus)
+
+        def harmonic_mean(x, y):
+            x_plus_y = actx.np.where(actx.np.greater(x + y, 0*x), x + y, 0*x+1)
+            return 2*x*y/x_plus_y
+
+        def replace_kappa(state, kappa):
+            from dataclasses import replace
+            new_tv = replace(state.tv, thermal_conductivity=kappa)
+            return replace(state, tv=new_tv)
+
+        kappa_harmonic_mean = harmonic_mean(
+            state_minus.tv.thermal_conductivity,
+            state_plus.tv.thermal_conductivity)
+
+        state_plus_harmonic_kappa = replace_kappa(state_plus, kappa_harmonic_mean)
+
+        # need to sum grad_t_plus and grad_t_minus
+        # assumes the harmonic flux
+        grad_t_interface = (grad_t_plus + grad_t_minus)/2.
+        viscous_flux = viscous_flux(state_plus_harmonic_kappa,
+                                    grad_cv_bc, grad_t_interface)
+
+        lengthscales = op.project(dcoll, dd_bdry_base, dd_bdry, self.lengthscales)
+
+        tau = (
+            self.heat_flux_penalty_amount * kappa_harmonic_mean / lengthscales)
+
+        # NS and diffusion use opposite sign conventions for flux; hence penalty
+        # is added here instead of subtracted
+        flux_without_penalty = viscous_flux@normal
+        return replace(
+            flux_without_penalty,
+            energy=(
+                flux_without_penalty.energy
+                + tau * (state_plus.temperature - state_minus.temperature)))
+
+    def get_external_t(self, dcoll, dd_bdry, gas_model, state_minus, **kwargs):
+        """Get the exterior T on the boundary."""
+        if dd_bdry.discretization_tag is not DISCR_TAG_BASE:
+            dd_bdry_base = dd_bdry.with_discr_tag(DISCR_TAG_BASE)
+            return op.project(dcoll, dd_bdry_base, dd_bdry, self.ext_t)
+        else:
+            return self.ext_t
+
+    def get_external_grad_t(
+            self, dcoll, dd_bdry, gas_model, state_minus, grad_cv_minus,
+            grad_t_minus, **kwargs):
+        """Get the exterior grad(T) on the boundary."""
+        if self.ext_grad_t is None:
+            raise ValueError(
+                "Boundary does not have external temperature gradient data.")
+        if dd_bdry.discretization_tag is not DISCR_TAG_BASE:
+            dd_bdry_base = dd_bdry.with_discr_tag(DISCR_TAG_BASE)
+            return op.project(dcoll, dd_bdry_base, dd_bdry, self.ext_grad_t)
+        else:
+            return self.ext_grad_t
 
 class InterfaceFluidBoundary(PrescribedFluidBoundary):
     """Interface boundary condition for the fluid side."""
@@ -444,6 +702,7 @@ def get_interface_boundaries(
         gas_model,
         fluid_dd, wall_dd,
         fluid_state, wall_kappa, wall_temperature,
+        interface_noslip=True,
         fluid_grad_temperature=None, wall_grad_temperature=None,
         wall_penalty_amount=None,
         quadrature_tag=DISCR_TAG_BASE,
@@ -496,18 +755,32 @@ def get_interface_boundaries(
                 fluid_state.array_context, dcoll, fluid_dd)
             * (0*fluid_state.temperature+1))
 
-        fluid_interface_boundaries = {
-            kappa_tpair.dd.domain_tag: InterfaceFluidBoundary(
-                kappa_tpair.ext,
-                temperature_tpair.ext,
-                grad_temperature_tpair.ext,
-                wall_penalty_amount,
-                lengthscales=op.project(dcoll,
-                    fluid_dd, temperature_tpair.dd, fluid_lengthscales))
-            for kappa_tpair, temperature_tpair, grad_temperature_tpair in zip(
-                kappa_inter_vol_tpairs[wall_dd, fluid_dd],
-                temperature_inter_vol_tpairs[wall_dd, fluid_dd],
-                grad_temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
+        if interface_noslip:
+            fluid_interface_boundaries = {
+                kappa_tpair.dd.domain_tag: InterfaceFluidBoundary(
+                    kappa_tpair.ext,
+                    temperature_tpair.ext,
+                    grad_temperature_tpair.ext,
+                    wall_penalty_amount,
+                    lengthscales=op.project(dcoll,
+                        fluid_dd, temperature_tpair.dd, fluid_lengthscales))
+                for kappa_tpair, temperature_tpair, grad_temperature_tpair in zip(
+                    kappa_inter_vol_tpairs[wall_dd, fluid_dd],
+                    temperature_inter_vol_tpairs[wall_dd, fluid_dd],
+                    grad_temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
+        else:
+            fluid_interface_boundaries = {
+                kappa_tpair.dd.domain_tag: InterfaceFluidSlipBoundary(
+                    kappa_tpair.ext,
+                    temperature_tpair.ext,
+                    grad_temperature_tpair.ext,
+                    wall_penalty_amount,
+                    lengthscales=op.project(dcoll,
+                        fluid_dd, temperature_tpair.dd, fluid_lengthscales))
+                for kappa_tpair, temperature_tpair, grad_temperature_tpair in zip(
+                    kappa_inter_vol_tpairs[wall_dd, fluid_dd],
+                    temperature_inter_vol_tpairs[wall_dd, fluid_dd],
+                    grad_temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
 
         wall_interface_boundaries = {
             kappa_tpair.dd.domain_tag: InterfaceWallBoundary(
@@ -519,13 +792,22 @@ def get_interface_boundaries(
                 temperature_inter_vol_tpairs[fluid_dd, wall_dd],
                 grad_temperature_inter_vol_tpairs[fluid_dd, wall_dd])}
     else:
-        fluid_interface_boundaries = {
-            kappa_tpair.dd.domain_tag: InterfaceFluidBoundary(
-                kappa_tpair.ext,
-                temperature_tpair.ext)
-            for kappa_tpair, temperature_tpair in zip(
-                kappa_inter_vol_tpairs[wall_dd, fluid_dd],
-                temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
+        if interface_noslip:
+            fluid_interface_boundaries = {
+                kappa_tpair.dd.domain_tag: InterfaceFluidBoundary(
+                    kappa_tpair.ext,
+                    temperature_tpair.ext)
+                for kappa_tpair, temperature_tpair in zip(
+                    kappa_inter_vol_tpairs[wall_dd, fluid_dd],
+                    temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
+        else:
+            fluid_interface_boundaries = {
+                kappa_tpair.dd.domain_tag: InterfaceFluidSlipBoundary(
+                    kappa_tpair.ext,
+                    temperature_tpair.ext)
+                for kappa_tpair, temperature_tpair in zip(
+                    kappa_inter_vol_tpairs[wall_dd, fluid_dd],
+                    temperature_inter_vol_tpairs[wall_dd, fluid_dd])}
 
         wall_interface_boundaries = {
             kappa_tpair.dd.domain_tag: InterfaceWallBoundary(
@@ -613,6 +895,8 @@ def coupled_ns_heat_operator(
         time=0.,
         fluid_gradient_numerical_flux_func=num_flux_central,
         inviscid_numerical_flux_func=inviscid_facial_flux_rusanov,
+        viscous_numerical_flux_func=viscous_facial_flux_harmonic,
+        interface_noslip=True,
         use_av=False,
         av_kwargs=None,
         return_gradients=False,
@@ -646,10 +930,12 @@ def coupled_ns_heat_operator(
 
     fluid_interface_boundaries_no_grad, wall_interface_boundaries_no_grad = \
         get_interface_boundaries(
-            dcoll,
-            gas_model,
-            fluid_dd, wall_dd,
-            fluid_state, wall_kappa, wall_temperature,
+            dcoll=dcoll,
+            gas_model=gas_model,
+            fluid_dd=fluid_dd, wall_dd=wall_dd,
+            fluid_state=fluid_state, wall_kappa=wall_kappa,
+            wall_temperature=wall_temperature,
+            interface_noslip=interface_noslip,
             _kappa_inter_vol_tpairs=kappa_inter_vol_tpairs,
             _temperature_inter_vol_tpairs=temperature_inter_vol_tpairs)
 
@@ -678,11 +964,14 @@ def coupled_ns_heat_operator(
 
     fluid_interface_boundaries, wall_interface_boundaries = \
         get_interface_boundaries(
-            dcoll,
-            gas_model,
-            fluid_dd, wall_dd,
-            fluid_state, wall_kappa, wall_temperature,
-            fluid_grad_temperature, wall_grad_temperature,
+            dcoll=dcoll,
+            gas_model=gas_model,
+            fluid_dd=fluid_dd, wall_dd=wall_dd,
+            fluid_state=fluid_state, wall_kappa=wall_kappa,
+            wall_temperature=wall_temperature,
+            fluid_grad_temperature=fluid_grad_temperature,
+            wall_grad_temperature=wall_grad_temperature,
+            interface_noslip=interface_noslip,
             wall_penalty_amount=wall_penalty_amount,
             _kappa_inter_vol_tpairs=kappa_inter_vol_tpairs,
             _temperature_inter_vol_tpairs=temperature_inter_vol_tpairs)
@@ -698,7 +987,7 @@ def coupled_ns_heat_operator(
     ns_result = ns_operator(
         dcoll, gas_model, fluid_state, fluid_all_boundaries,
         time=time, quadrature_tag=quadrature_tag, dd=fluid_dd,
-        viscous_numerical_flux_func=viscous_facial_flux_harmonic,
+        viscous_numerical_flux_func=viscous_numerical_flux_func,
         return_gradients=return_gradients,
         operator_states_quad=fluid_operator_states_quad,
         grad_t=fluid_grad_temperature, comm_tag=_FluidOperatorTag)

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -154,7 +154,6 @@ class InterfaceFluidSlipBoundary(PrescribedFluidBoundary):
             * gas_model.eos.get_internal_energy(
                 temperature=ext_t,
                 species_mass_fractions=cv_minus.species_mass_fractions))
-        #ext_kinetic_energy = gas_model.eos.kinetic_energy(cv_minus)
         ext_kinetic_energy = 0.5*np.dot(ext_mom, ext_mom)/cv_minus.mass
         ext_energy = ext_internal_energy + ext_kinetic_energy
 
@@ -225,7 +224,8 @@ class InterfaceFluidSlipBoundary(PrescribedFluidBoundary):
             grad_av_minus.dim, mass=grad_av_minus.mass, energy=ext_grad_energy,
             momentum=grad_av_minus.momentum, species_mass=ext_grad_species_mass)
 
-    def get_external_grad_cv(self, state_minus, state_plus, grad_cv_minus, normal, **kwargs):
+    def get_external_grad_cv(self, state_minus, state_plus, grad_cv_minus,
+                             normal, **kwargs):
         """
         Return external grad(CV) used in the boundary calculation of viscous flux.
 


### PR DESCRIPTION
Change to add a new boundary condition for the fluid/wall interface. New implementation uses a slip boundary condition vs the noslip already implemented.

Include option to enable from the driver.
